### PR TITLE
fix: update Tailwind PostCSS bridge

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
+      # Install Tailwind v4 PostCSS bridge to satisfy Tailwind's plugin requirement at build time
+      - run: npm i -D @tailwindcss/postcss
       - run: npm run build
       - name: Add 404 fallback for SPA deep links
         run: cp dist/el-gaon/browser/index.html dist/el-gaon/browser/404.html

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
+    '@tailwindcss/postcss': {}
   }
 };


### PR DESCRIPTION
## Summary
- use Tailwind v4 postcss bridge in configuration
- install the bridge during GH Pages deploy workflow

## Testing
- `npm test` *(fails: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin...)*
- `npm run build` *(fails: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin...)*

------
https://chatgpt.com/codex/tasks/task_e_68b80824f6ec8332bb3bc263ce0e582b