### PR TITLE
Expose year property for footer binding

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -17,5 +17,5 @@
 </main>
 
 <footer class="bg-blackx text-white/70 text-sm py-6">
-  <div class="mx-auto max-w-6xl px-4">© {{ new Date().getFullYear() }} Taquería El Ga’on</div>
+  <div class="mx-auto max-w-6xl px-4">© {{ year }} Taquería El Ga’on</div>
 </footer>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -9,4 +9,7 @@ import { RouterOutlet } from '@angular/router';
 })
 export class App {
   protected readonly title = signal('el-gaon');
+
+  // Expose the current year for footer binding (Angular templates should avoid `new`/side effects)
+  public readonly year = new Date().getFullYear();
 }


### PR DESCRIPTION
## Summary
- expose current year via public readonly property on root component
- bind footer copyright to year property

## Testing
- `NG_CLI_ANALYTICS=false npm test -- --watch=false --browsers=ChromeHeadless` *(fails: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68b810f91f3c833288ed0258fec6e2d9