### PR TITLE
chore: allow gh-pages workflow to push

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,6 +2,10 @@ name: Deploy GH Pages
 on:
   push:
     branches: [ main ]
+ 
+permissions:
+  contents: write  # allow actions-gh-pages to push to gh-pages
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant write access to GitHub token for gh-pages workflow

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8138f17fc83329648b26bd60fd620