### PR TITLE
feat: implement content phase

### DIFF
--- a/public/data/business.json
+++ b/public/data/business.json
@@ -1,0 +1,10 @@
+{
+  "name": "Taquería El Ga’on",
+  "address": "2 Poniente #218, Centro, Tehuacán, Puebla",
+  "instagram": "taqueria_elgaon",
+  "facebook": "taqueria_elgaon",
+  "whatsapp": {
+    "number": "",
+    "prefill": "Hola El Ga’on, quiero ordenar:"
+  }
+}

--- a/public/data/menu.json
+++ b/public/data/menu.json
@@ -1,0 +1,37 @@
+{
+  "categories": [
+    {
+      "id": "tacos",
+      "label": "Tacos",
+      "items": [
+        { "name": "Arrachera", "prices": { "maiz": 42, "harina": 46, "con": 52 } },
+        { "name": "Sirloin",   "prices": { "maiz": 45, "harina": 49, "con": 55 } },
+        { "name": "New York",  "prices": { "maiz": 45, "harina": 49, "con": 55 } },
+        { "name": "Picanha",   "prices": { "maiz": 45, "harina": 49, "con": 55 } },
+        { "name": "Rib Eye",   "prices": { "maiz": 42, "harina": 46, "con": 52 } },
+        { "name": "Pechuga",   "prices": { "maiz": 42, "harina": 46, "con": 52 } },
+        { "name": "Cecina",    "prices": { "maiz": 42, "harina": 46, "con": 52 } },
+        { "name": "Chuleta",   "prices": { "maiz": 39, "harina": 43, "con": 49 } }
+      ],
+      "notes": "Precios por taco. 'con' = con queso."
+    },
+    {
+      "id": "bebidas",
+      "label": "Fuente de sodas",
+      "items": [
+        { "name": "Jarritos", "price": 35 },
+        { "name": "Sangría casera", "price": 35 },
+        { "name": "Agua natural", "price": 25 },
+        { "name": "Agua del día 1/2 litro", "price": 35 },
+        { "name": "Agua del día 1 litro", "price": 65 }
+      ]
+    },
+    {
+      "id": "postres",
+      "label": "Postres",
+      "items": [
+        { "name": "Postre del día", "price": 50 }
+      ]
+    }
+  ]
+}

--- a/public/data/promos.json
+++ b/public/data/promos.json
@@ -1,0 +1,13 @@
+{
+  "active": [
+    {
+      "title": "Bienvenido conocedor ✨",
+      "body": "Pregunta por la gaonera con queso 🧀",
+      "start": "2025-01-01",
+      "end": "2025-12-31",
+      "cta": "Ver menú",
+      "href": "/menu"
+    }
+  ],
+  "upcoming": []
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,13 +1,16 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
-import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes), provideClientHydration(withEventReplay())
+    provideRouter(routes),
+    provideClientHydration(withEventReplay()),
+    provideHttpClient()
   ]
 };

--- a/src/app/components/menu-tabs/menu-tabs.component.ts
+++ b/src/app/components/menu-tabs/menu-tabs.component.ts
@@ -1,0 +1,67 @@
+import { Component, Signal, computed, effect, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataService, Category, TacoItem } from '../../data/data.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-menu-tabs',
+  imports: [CommonModule],
+  template: `
+  <section class="bg-blackx text-white px-4 py-8 mx-auto max-w-6xl">
+    <h1 class="text-3xl md:text-4xl font-display mb-4">Menú</h1>
+
+    <div class="flex gap-2 overflow-x-auto pb-2 border-b border-white/10">
+      <button *ngFor="let c of categories()"
+              (click)="activeId.set(c.id)"
+              class="px-4 py-2 rounded-lg text-sm md:text-base"
+              [class.bg-gold]="activeId() === c.id"
+              [class.text-blackx]="activeId() === c.id"
+              [class.bg-white/10]="activeId() !== c.id">
+        {{ c.label }}
+      </button>
+    </div>
+
+    <div class="mt-6 space-y-4" *ngIf="activeCategory() as cat">
+      <p *ngIf="cat.notes" class="text-white/60 text-sm">{{ cat.notes }}</p>
+
+      <div *ngFor="let item of cat.items" class="flex items-start justify-between gap-4 border-b border-white/10 pb-3">
+        <div>
+          <h3 class="font-semibold text-lg">{{ item.name }}</h3>
+        </div>
+
+        <!-- Tacos have three price chips; simples have one -->
+        <div class="flex items-center gap-2 text-sm shrink-0">
+          <ng-container *ngIf="isTaco(item); else simplePrice">
+            <span class="inline-block px-2 py-1 rounded bg-white/10">Maíz ${{ (item as TacoItem).prices.maiz }}</span>
+            <span class="inline-block px-2 py-1 rounded bg-white/10">Harina ${{ (item as TacoItem).prices.harina }}</span>
+            <span class="inline-block px-2 py-1 rounded bg-vermillion">Con ${{ (item as TacoItem).prices.con }}</span>
+          </ng-container>
+          <ng-template #simplePrice>
+            <span class="inline-block px-2 py-1 rounded bg-white/10">${{ (item as any).price }}</span>
+          </ng-template>
+        </div>
+      </div>
+    </div>
+  </section>
+  `
+})
+export class MenuTabsComponent {
+  private data = inject(DataService);
+  protected categories = signal<Category[]>([]);
+  protected activeId = signal<string>('tacos');
+
+  constructor() {
+    this.data.menu().subscribe(m => this.categories.set(m.categories));
+    effect(() => {
+      if (!this.categories().some(c => c.id === this.activeId())) {
+        const first = this.categories()[0]?.id;
+        if (first) this.activeId.set(first);
+      }
+    });
+  }
+
+  protected activeCategory = computed(() => this.categories().find(c => c.id === this.activeId()) ?? null);
+  protected isTaco(item: any): item is TacoItem {
+    return !!item?.prices && typeof item.prices.maiz === 'number';
+  }
+}

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -1,0 +1,46 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+
+export interface TacoItem { name: string; prices: { maiz: number; harina: number; con: number }; }
+export interface SimpleItem { name: string; price: number; }
+export interface Category {
+  id: 'tacos' | 'bebidas' | 'postres' | (string & {});
+  label: string;
+  items: (TacoItem | SimpleItem)[];
+  notes?: string;
+}
+export interface MenuData { categories: Category[]; }
+
+export interface Promo { title: string; body?: string; start?: string; end?: string; cta?: string; href?: string; }
+export interface PromosData { active: Promo[]; upcoming?: Promo[]; }
+
+export interface Business {
+  name: string;
+  address?: string;
+  instagram?: string;
+  facebook?: string;
+  whatsapp?: { number?: string; prefill?: string };
+}
+
+@Injectable({ providedIn: 'root' })
+export class DataService {
+  private http = inject(HttpClient);
+  private base = '/data'; // served from /public/data
+
+  menu(): Observable<MenuData> {
+    return this.http.get<MenuData>(`${this.base}/menu.json`);
+  }
+  promos(): Observable<PromosData> {
+    return this.http.get<PromosData>(`${this.base}/promos.json`);
+  }
+  business(): Observable<Business> {
+    return this.http.get<Business>(`${this.base}/business.json`);
+  }
+
+  whatsappUrl(message: string, biz?: Business): string {
+    const num = biz?.whatsapp?.number?.replace(/[^\d]/g, '') ?? '';
+    const base = num ? `https://wa.me/${num}` : 'https://wa.me/';
+    return `${base}?text=${encodeURIComponent(message)}`;
+  }
+}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -7,6 +7,10 @@
   </div>
 </app-hero-video>
 
+<app-promo-ticker></app-promo-ticker>
+<app-business-cta></app-business-cta>
+
 <!-- Optional decorative gradient layer below if you still want it:
-<div class="absolute inset-0 [background:radial-gradient(circle_at_30%_20%,rgba(216,182,60,.25),transparent_40%),radial-gradient(circle_at_70%_80%,rgba(196,38,49,.25),transparent_45%)]"></div>
+<div class="absolute inset-0 [background:radial-gradient(circle_at_30%_20%,rgba(216,182,60,.25),transparent_40%),radial-gradient
+(circle_at_70%_80%,rgba(196,38,49,.25),transparent_45%)]"></div>
 -->

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,11 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { HeroVideoComponent } from '../../shared/hero-video/hero-video.component';
+import { PromoTickerComponent } from '../../shared/promo-ticker/promo-ticker.component';
+import { BusinessCtaComponent } from '../../shared/business-cta/business-cta.component';
 
 @Component({
   standalone: true,
   selector: 'app-home',
-  imports: [RouterLink, HeroVideoComponent],
+  imports: [RouterLink, HeroVideoComponent, PromoTickerComponent, BusinessCtaComponent],
   templateUrl: './home.component.html',
   styleUrl: './home.component.css'
 })

--- a/src/app/pages/menu/menu.component.ts
+++ b/src/app/pages/menu/menu.component.ts
@@ -1,8 +1,14 @@
 import { Component } from '@angular/core';
+import { MenuTabsComponent } from '../../components/menu-tabs/menu-tabs.component';
+import { BusinessCtaComponent } from '../../shared/business-cta/business-cta.component';
 
 @Component({
   standalone: true,
   selector: 'app-menu',
-  template: `<section class="p-6 text-white"><h1 class="text-3xl font-display mb-2">Menú</h1><p class="text-white/80">Próximamente: cartas y precios.</p></section>`
+  imports: [MenuTabsComponent, BusinessCtaComponent],
+  template: `
+    <app-menu-tabs></app-menu-tabs>
+    <app-business-cta></app-business-cta>
+  `
 })
 export class MenuComponent {}

--- a/src/app/pages/promociones/promociones.component.ts
+++ b/src/app/pages/promociones/promociones.component.ts
@@ -1,8 +1,17 @@
 import { Component } from '@angular/core';
+import { PromoTickerComponent } from '../../shared/promo-ticker/promo-ticker.component';
 
 @Component({
   standalone: true,
   selector: 'app-promociones',
-  template: `<section class="p-6 text-white"><h1 class="text-3xl font-display mb-2">Promociones</h1><p class="text-white/80">Próximamente: posters y vigencias.</p></section>`
+  imports: [PromoTickerComponent],
+  template: `
+    <section class="bg-blackx min-h-[40svh]">
+      <app-promo-ticker></app-promo-ticker>
+      <div class="mx-auto max-w-6xl px-4 py-8 text-white/80">
+        Más promociones próximamente.
+      </div>
+    </section>
+  `
 })
 export class PromocionesComponent {}

--- a/src/app/shared/business-cta/business-cta.component.ts
+++ b/src/app/shared/business-cta/business-cta.component.ts
@@ -1,0 +1,42 @@
+import { Component, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataService, Business } from '../../data/data.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-business-cta',
+  imports: [CommonModule],
+  template: `
+  <section class="bg-blackx text-white">
+    <div class="mx-auto max-w-6xl px-4 py-8 flex flex-col md:flex-row md:items-center gap-4">
+      <div class="grow">
+        <h2 class="text-2xl font-display">¿Listo para ordenar?</h2>
+        <p class="text-white/70" *ngIf="biz() as b">{{ b.address }}</p>
+      </div>
+      <div class="flex items-center gap-3">
+        <a [href]="waUrl" target="_blank" rel="noopener"
+           class="px-5 py-3 rounded-lg bg-vermillion text-white font-semibold hover:opacity-90 transition">
+          WhatsApp
+        </a>
+        <a *ngIf="biz()?.instagram" [href]="'https://instagram.com/' + biz()?.instagram" target="_blank" rel="noopener"
+           class="text-white/80 hover:text-white">Instagram</a>
+        <a *ngIf="biz()?.facebook" [href]="'https://facebook.com/' + biz()?.facebook" target="_blank" rel="noopener"
+           class="text-white/80 hover:text-white">Facebook</a>
+      </div>
+    </div>
+  </section>
+  `
+})
+export class BusinessCtaComponent {
+  private data = inject(DataService);
+  protected biz = signal<Business | null>(null);
+  protected waUrl = 'https://wa.me/';
+
+  constructor() {
+    this.data.business().subscribe(b => {
+      this.biz.set(b);
+      const pre = b.whatsapp?.prefill || 'Hola El Ga’on, quiero ordenar:';
+      this.waUrl = this.data.whatsappUrl(pre, b);
+    });
+  }
+}

--- a/src/app/shared/promo-ticker/promo-ticker.component.ts
+++ b/src/app/shared/promo-ticker/promo-ticker.component.ts
@@ -1,0 +1,48 @@
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataService, Promo } from '../../data/data.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-promo-ticker',
+  imports: [CommonModule],
+  template: `
+  <section class="bg-blackx text-white border-t border-white/10">
+    <div class="mx-auto max-w-6xl px-4 py-3" aria-live="polite">
+      <div *ngIf="promo() as p" class="flex items-center gap-3">
+        <span class="inline-block px-2 py-1 rounded bg-gold text-blackx text-xs font-semibold">PROMO</span>
+        <span class="text-sm md:text-base">{{ p.title }} <span *ngIf="p.body" class="text-white/70">— {{ p.body }}</span></span>
+        <a *ngIf="p.href" [href]="p.href" class="ml-auto text-vermillion hover:underline text-sm">{{ p.cta || 'Ver más' }}</a>
+      </div>
+    </div>
+  </section>
+  `
+})
+export class PromoTickerComponent implements OnInit, OnDestroy {
+  private data = inject(DataService);
+  protected list: Promo[] = [];
+  protected idx = 0;
+  protected promo = signal<Promo | null>(null);
+  private timer?: any;
+  private reduced = false;
+
+  ngOnInit(): void {
+    if (typeof window !== 'undefined' && 'matchMedia' in window) {
+      this.reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+    this.data.promos().subscribe(p => {
+      this.list = p.active || [];
+      this.idx = 0;
+      this.update();
+      if (!this.reduced && this.list.length > 1) {
+        this.timer = setInterval(() => { this.idx = (this.idx + 1) % this.list.length; this.update(); }, 6500);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  private update() { this.promo.set(this.list[this.idx] ?? null); }
+}


### PR DESCRIPTION
## Summary
- add owner-editable JSON for menu, promos, and business info
- provide HttpClient and data service to fetch JSON data
- introduce menu tabs, promo ticker, and business CTA components and wire pages

## Testing
- `npm test` *(fails: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin)*
- `npm run build` *(fails: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68b824be325c8332993017f50b1a35d9