### PR TITLE
chore: use official GitHub Pages action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,84 +1,92 @@
-name: Deploy GH Pages
+name: Deploy GH Pages (Actions)
+
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
-  contents: write  # allow actions-gh-pages to push to gh-pages
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm install --no-audit --no-fund
-      - run: npm run build
 
-      # Resolve the real publish directory by locating an index file.
-      # Handles:
-      #  - dist/el-gaon/browser/index.html
-      #  - dist/el-gaon/index.html
-      #  - dist/**/index.csr.html (normalize to index.html)
-      - name: Resolve publish directory & add SPA 404
+      - name: Install
+        run: npm install --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      # Detect publish directory; handle SSR layouts that emit index.csr.html
+      - name: Resolve publish directory
+        id: publishdir
         shell: bash
         run: |
           set -euo pipefail
           root="dist/el-gaon"
-
           pick_index() {
             local dir="$1"
             if [[ -f "$dir/index.html" ]]; then
-              echo "$dir/index.html"
+              echo "$dir"
               return 0
             fi
             if [[ -f "$dir/index.csr.html" ]]; then
               cp "$dir/index.csr.html" "$dir/index.html"
-              echo "$dir/index.html"
+              echo "$dir"
               return 0
             fi
             return 1
           }
 
-          INDEX=""
-          if [[ -d "$root/browser" ]]; then
-            if INDEX=$(pick_index "$root/browser"); then
-              PUBLISH_DIR="$root/browser"
-            fi
-          fi
-
-          if [[ -z "${INDEX:-}" ]] && [[ -d "$root" ]]; then
-            if INDEX=$(pick_index "$root"); then
-              PUBLISH_DIR="$root"
-            fi
-          fi
-
-          if [[ -z "${INDEX:-}" ]]; then
-            # Fallback: find any index(.csr).html under dist
+          PUBLISH_DIR=""
+          if [[ -d "$root/browser" ]] && pick_index "$root/browser" >/dev/null; then
+            PUBLISH_DIR="$root/browser"
+          elif [[ -d "$root" ]] && pick_index "$root" >/dev/null; then
+            PUBLISH_DIR="$root"
+          else
             cand=$(find dist -maxdepth 5 -type f \( -name index.html -o -name index.csr.html \) | head -n1 || true)
             if [[ -z "$cand" ]]; then
-              echo "Build output not found. Dist tree:"
+              echo "No index file found under dist. Dist tree:"
               find dist -maxdepth 5 -print || true
               exit 1
             fi
             PUBLISH_DIR="$(dirname "$cand")"
             if [[ "${cand##*/}" == "index.csr.html" ]]; then
               cp "$cand" "$PUBLISH_DIR/index.html"
-              INDEX="$PUBLISH_DIR/index.html"
-            else
-              INDEX="$cand"
             fi
           fi
 
-          echo "PUBLISH_DIR=$PUBLISH_DIR" >> "$GITHUB_ENV"
-          cp "$INDEX" "$PUBLISH_DIR/404.html"
-          echo "::notice::Publishing from $PUBLISH_DIR"
+          echo "PUBLISH_DIR=$PUBLISH_DIR" >> "$GITHUB_OUTPUT"
+          cp "$PUBLISH_DIR/index.html" "$PUBLISH_DIR/404.html"
+          touch "$PUBLISH_DIR/.nojekyll"
+          echo "Resolved publish dir: $PUBLISH_DIR"
+          ls -la "$PUBLISH_DIR"
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.PUBLISH_DIR }}
-          force_orphan: true
+          path: ${{ steps.publishdir.outputs.PUBLISH_DIR }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- migrate gh-pages workflow to official GitHub Pages deploy action

## Testing
- `npm test --silent -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bf665b2483329c73496299be02d3