### PR TITLE
feat: improve hero video autoplay

### DIFF
--- a/src/app/shared/hero-video/hero-video.component.ts
+++ b/src/app/shared/hero-video/hero-video.component.ts
@@ -11,15 +11,27 @@ import { CommonModule } from '@angular/common';
       <video
         #vid
         class="w-full h-[70dvh] object-cover"
-        [attr.src]="src"
-        [attr.poster]="poster"
+        [src]="src"
+        [poster]="poster"
         autoplay
         muted
         loop
         playsinline
+        webkit-playsinline
         preload="metadata"
         aria-hidden="true">
+        <source [src]="src" type="video/mp4" />
       </video>
+
+      <!-- Fallback overlay if autoplay is blocked -->
+      <button
+        *ngIf="autoplayBlocked"
+        (click)="tapToPlay($event)"
+        class="absolute inset-0 flex items-center justify-center bg-black/40 text-white">
+        <span class="px-5 py-3 rounded-lg bg-vermillion text-white font-semibold shadow hover:opacity-90 transition">
+          Tocar para reproducir
+        </span>
+      </button>
     </ng-container>
 
     <ng-template #posterTpl>
@@ -32,7 +44,7 @@ import { CommonModule } from '@angular/common';
   `,
 })
 export class HeroVideoComponent implements AfterViewInit, OnDestroy {
-  /** Path to the MP4 video. Replace this with the real Sora export when ready. */
+  /** Path to the MP4 video. */
   @Input() src: string = 'assets/video/hero_loop.mp4';
 
   /** Poster image shown on load and for reduced-motion users. */
@@ -40,26 +52,53 @@ export class HeroVideoComponent implements AfterViewInit, OnDestroy {
 
   @ViewChild('vid') vid?: ElementRef<HTMLVideoElement>;
   prefersReducedMotion = false;
+  autoplayBlocked = false;
   private observer?: IntersectionObserver;
 
   ngAfterViewInit(): void {
-    // Reduced motion preference (safe guard for SSR if ever enabled)
+    // Respect reduced motion (safe-guard for SSR if ever enabled)
     if (typeof window !== 'undefined' && 'matchMedia' in window) {
       this.prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     }
+    if (this.prefersReducedMotion) return;
 
-    // Pause video when off-screen to save battery/data
-    if (this.vid && typeof window !== 'undefined' && 'IntersectionObserver' in window) {
-      const v = this.vid.nativeElement;
+    const v = this.vid?.nativeElement;
+    if (!v) return;
+
+    // Make iOS Safari happy: set properties and attributes before attempting play
+    v.muted = true;
+    (v as any).playsInline = true;
+    v.setAttribute('playsinline', '');
+    v.setAttribute('webkit-playsinline', '');
+    v.preload = 'metadata';
+
+    const tryPlay = () => v.play().then(() => {
+      this.autoplayBlocked = false;
+    }).catch(() => {
+      // If blocked, show tap overlay
+      this.autoplayBlocked = true;
+    });
+
+    // Try immediately and once the media can play
+    tryPlay();
+    v.addEventListener('canplay', () => tryPlay(), { once: true });
+
+    // Pause when off-screen, play when on-screen (saves battery/data)
+    if (typeof window !== 'undefined' && 'IntersectionObserver' in window) {
       this.observer = new IntersectionObserver(([entry]) => {
-        if (!entry.isIntersecting) {
-          v.pause();
-        } else if (v.paused) {
-          v.play().catch(() => {});
-        }
+        if (!entry.isIntersecting) v.pause();
+        else if (v.paused) v.play().catch(() => { this.autoplayBlocked = true; });
       }, { threshold: 0.1 });
       this.observer.observe(v);
     }
+  }
+
+  tapToPlay(evt: Event) {
+    evt.stopPropagation();
+    const v = this.vid?.nativeElement;
+    if (!v) return;
+    v.muted = true; // keep muted for autoplay policy
+    v.play().then(() => { this.autoplayBlocked = false; }).catch(() => { /* keep overlay */ });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Summary
- ensure hero video respects reduced motion and autoplays silently
- add tap-to-play overlay and viewport-based playback control

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d234746883329f7df76ddd9f13a9