### PR TITLE
Enable active navbar links and lazy-loaded location map

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,12 +2,12 @@
   <nav class="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
     <a routerLink="/" class="font-display text-lg">El Ga’on</a>
     <div class="flex gap-4 text-white/90">
-      <a routerLink="/menu" class="hover:text-white">Menú</a>
-      <a routerLink="/promociones" class="hover:text-white">Promos</a>
-      <a routerLink="/galeria" class="hover:text-white">Galería</a>
-      <a routerLink="/nosotros" class="hover:text-white">Nosotros</a>
-      <a routerLink="/ubicacion" class="hover:text-white">Ubicación</a>
-      <a routerLink="/contacto" class="hover:text-white">Contacto</a>
+      <a routerLink="/menu" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Menú</a>
+      <a routerLink="/promociones" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Promos</a>
+      <a routerLink="/galeria" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Galería</a>
+      <a routerLink="/nosotros" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Nosotros</a>
+      <a routerLink="/ubicacion" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Ubicación</a>
+      <a routerLink="/contacto" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Contacto</a>
     </div>
   </nav>
 </header>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,10 @@
 import { Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { ConsentBannerComponent } from './components/consent-banner/consent-banner.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, ConsentBannerComponent],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, ConsentBannerComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/pages/ubicacion/ubicacion.component.ts
+++ b/src/app/pages/ubicacion/ubicacion.component.ts
@@ -10,33 +10,43 @@ import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
   <section class="bg-blackx text-white">
     <div class="mx-auto max-w-6xl px-4 py-8">
       <h1 class="text-3xl md:text-4xl font-display mb-4">Ubicación</h1>
-      <p class="text-white/70 mb-4">2 Poniente #218, Centro, Tehuacán, Puebla.</p>
+      <p class="text-white/70 mb-6">2 Poniente #218, Centro, Tehuacán, Puebla.</p>
 
       <div class="rounded-xl overflow-hidden border border-white/10">
         <!-- Preview image; clicking loads the iframe -->
-        <button *ngIf="!loaded" (click)="loadMap()" class="block w-full text-left group">
-          <img src="./images/map-preview.svg" alt="Mostrar mapa de Google" class="w-full h-auto" loading="lazy" decoding="async" />
-          <div class="p-4 bg-blackx flex items-center justify-between">
-            <span class="text-white/80">Cargar mapa interactivo</span>
-            <span class="text-gold group-hover:underline">Abrir</span>
-          </div>
+        <button
+          *ngIf="!loaded"
+          type="button"
+          (click)="loadMap()"
+          class="relative block w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-vermillion"
+          aria-label="Mostrar mapa de Google (carga al hacer clic)">
+          <img
+            src="images/map-preview.svg"
+            alt="Vista previa del mapa — haz clic para cargar Google Maps"
+            class="w-full h-auto"
+            loading="lazy"
+            decoding="async" />
+          <span class="absolute bottom-3 right-3 px-3 py-1 rounded-lg bg-vermillion text-white text-sm shadow">
+            Click para mostrar mapa
+          </span>
         </button>
 
-        <div *ngIf="loaded" class="w-full aspect-[4/3] bg-blackx">
-          <iframe
-            [src]="embedSafe"
-            width="100%" height="100%"
-            style="border:0;"
-            allowfullscreen=""
-            loading="lazy"
-            referrerpolicy="no-referrer-when-downgrade"
-            title="Mapa Taquería El Ga’on">
-          </iframe>
-        </div>
+        <!-- Lazy Google Maps (only after click) -->
+        <iframe
+          *ngIf="loaded"
+          [src]="embedSafe"
+          width="100%"
+          height="420"
+          style="border:0;"
+          loading="lazy"
+          referrerpolicy="no-referrer-when-downgrade"
+          allowfullscreen
+          title="Mapa de Taquería El Ga’on">
+        </iframe>
       </div>
 
-      <div class="mt-6">
-        <a class="text-vermillion hover:underline" href="https://maps.app.goo.gl/UxpdeZjwFthaKxne7" target="_blank" rel="noopener">Abrir en Google Maps</a>
+      <div class="mt-6 text-white/80 text-sm">
+        <p>Estacionamiento cercano y servicio para llevar.</p>
       </div>
     </div>
   </section>
@@ -46,6 +56,7 @@ export class UbicacionComponent {
   loaded = false;
   embedSafe!: SafeResourceUrl;
 
+  // Full embed URL from your earlier message
   private readonly embed = 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d473.0515482394382!2d-97.3976427962211!3d18.464998851814144!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x85c5bd003ebdd59b%3A0xf6cfd9ebb6912537!2zVGFxdWVyaWEg4oCcRWwgR2HigJlPbuKAnQ!5e0!3m2!1sen!2smx!4v1756935813714!5m2!1sen!2smx';
 
   constructor(private s: DomSanitizer) {}
@@ -55,3 +66,4 @@ export class UbicacionComponent {
     this.loaded = true;
   }
 }
+


### PR DESCRIPTION
## Summary
- add RouterLink and RouterLinkActive to app shell
- highlight navbar links when active with routerLinkActive/ariaCurrentWhenActive
- replace Ubicación page with click-to-load Google Map

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ee89a0c88332abdc8d94921020e3