### PR TITLE
Update business contact info and add contact page with brand styling

### DIFF
--- a/public/data/business.json
+++ b/public/data/business.json
@@ -1,10 +1,11 @@
 {
   "name": "Taquería El Ga’on",
   "address": "2 Poniente #218, Centro, Tehuacán, Puebla",
-  "instagram": "taqueria_elgaon",
-  "facebook": "taqueria_elgaon",
+  "instagram": "https://www.instagram.com/taqueria_el_gaon",
+  "facebook": "https://www.facebook.com/p/Taquería-El-Gaon-61574898375073",
   "whatsapp": {
-    "number": "",
-    "prefill": "Hola El Ga’on, quiero ordenar:"
+    "number": "2382489890",
+    "prefill": "Hola El Ga’on, quiero ordenar: Gaonera x3 + Queso"
   }
 }
+

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,17 +2,17 @@
   <nav class="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
     <a routerLink="/" class="font-display text-lg">El Ga’on</a>
     <div class="flex gap-4 text-white/90">
-      <a routerLink="/menu" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Menú</a>
-      <a routerLink="/promociones" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Promos</a>
-      <a routerLink="/galeria" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Galería</a>
-      <a routerLink="/nosotros" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Nosotros</a>
-      <a routerLink="/ubicacion" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Ubicación</a>
-      <a routerLink="/contacto" routerLinkActive="text-white" class="hover:text-white" ariaCurrentWhenActive="page">Contacto</a>
+      <a routerLink="/menu" routerLinkActive="text-white" class="hover:text-white transition-colors" ariaCurrentWhenActive="page">Menú</a>
+      <a routerLink="/promociones" routerLinkActive="text-white" class="hover:text-white transition-colors" ariaCurrentWhenActive="page">Promos</a>
+      <a routerLink="/galeria" routerLinkActive="text-white" class="hover:text-white transition-colors" ariaCurrentWhenActive="page">Galería</a>
+      <a routerLink="/nosotros" routerLinkActive="text-white" class="hover:text-white transition-colors" ariaCurrentWhenActive="page">Nosotros</a>
+      <a routerLink="/ubicacion" routerLinkActive="text-white" class="hover:text-white transition-colors" ariaCurrentWhenActive="page">Ubicación</a>
+      <a routerLink="/contacto" routerLinkActive="text-white" class="hover:text-white transition-colors" ariaCurrentWhenActive="page">Contacto</a>
     </div>
   </nav>
 </header>
 
-<main class="bg-blackx min-h-[70svh]">
+<main class="bg-blackx min-h-[70svh] font-body">
   <router-outlet />
 </main>
 
@@ -38,8 +38,10 @@
     <div>
       <div class="text-white mb-2">Social</div>
       <div class="flex gap-4">
-        <a href="https://instagram.com/taqueria_elgaon" target="_blank" rel="noopener" class="hover:text-white">Instagram</a>
-        <a href="https://facebook.com/taqueria_elgaon" target="_blank" rel="noopener" class="hover:text-white">Facebook</a>
+        <a href="https://www.instagram.com/taqueria_el_gaon" target="_blank" rel="noopener"
+           class="hover:text-gold transition-colors">Instagram</a>
+        <a href="https://www.facebook.com/p/Taquería-El-Gaon-61574898375073" target="_blank" rel="noopener"
+           class="hover:text-gold transition-colors">Facebook</a>
       </div>
     </div>
   </div>

--- a/src/app/components/business-cta/business-cta.component.ts
+++ b/src/app/components/business-cta/business-cta.component.ts
@@ -13,7 +13,8 @@ import { AnalyticsService } from '../../core/analytics.service';
       <div class="grow">
         <h2 class="text-2xl font-display">¿Listo para ordenar?</h2>
         <p class="text-white/70" *ngIf="biz() as b">
-          <a [href]="mapsUrl" target="_blank" rel="noopener" (click)="onMapsClick()">{{ b.address }}</a>
+          <a [href]="mapsUrl" target="_blank" rel="noopener" (click)="onMapsClick()"
+             class="hover:text-gold transition-colors">{{ b.address }}</a>
         </p>
       </div>
       <div class="flex items-center gap-3">

--- a/src/app/pages/contacto/contacto.component.ts
+++ b/src/app/pages/contacto/contacto.component.ts
@@ -1,8 +1,75 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataService, Business } from '../../data/data.service';
 
 @Component({
   standalone: true,
   selector: 'app-contacto',
-  template: `<section class="p-6 text-white"><h1 class="text-3xl font-display mb-2">Contacto</h1><p class="text-white/80">Próximamente: WhatsApp y redes.</p></section>`
+  imports: [CommonModule],
+  template: `
+  <section class="bg-blackx text-white">
+    <div class="mx-auto max-w-6xl px-4 py-10">
+      <h1 class="text-3xl md:text-4xl font-display mb-6">Contacto</h1>
+
+      <ng-container *ngIf="biz as b">
+        <div class="grid gap-6 md:grid-cols-2">
+          <div class="space-y-3">
+            <div class="text-white/80">Dirección</div>
+            <div class="font-medium">{{ b.address || 'Tehuacán, Puebla' }}</div>
+          </div>
+
+          <div class="space-y-3">
+            <div class="text-white/80">Teléfono</div>
+            <div class="font-medium">
+              <a [href]="'tel:+52' + (b.whatsapp?.number || '2382489890')" class="hover:text-gold transition-colors">
+                +52 {{ (b.whatsapp?.number || '2382489890') }}
+              </a>
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <div class="text-white/80">Instagram</div>
+            <div class="font-medium">
+              <a [href]="b.instagram || 'https://www.instagram.com/taqueria_el_gaon'"
+                 target="_blank" rel="noopener"
+                 class="hover:text-gold transition-colors">
+                 @taqueria_el_gaon
+              </a>
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <div class="text-white/80">Facebook</div>
+            <div class="font-medium">
+              <a [href]="b.facebook || 'https://www.facebook.com/p/Taquería-El-Gaon-61574898375073'"
+                 target="_blank" rel="noopener"
+                 class="hover:text-gold transition-colors">
+                 Taquería El Ga’on
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-8">
+          <a [href]="wa(b)" class="inline-flex items-center px-5 py-3 rounded-xl bg-vermillion text-white font-semibold hover:opacity-90 transition">
+            WhatsApp
+          </a>
+        </div>
+      </ng-container>
+    </div>
+  </section>
+  `
 })
-export class ContactoComponent {}
+export class ContactoComponent {
+  private data = inject(DataService);
+  biz?: Business;
+
+  constructor() {
+    this.data.business().subscribe(b => this.biz = b);
+  }
+
+  wa(b: Business | undefined): string {
+    const pre = b?.whatsapp?.prefill || 'Hola El Ga’on, quiero ordenar:';
+    return this.data.whatsappUrl(pre, b);
+  }
+}


### PR DESCRIPTION
## Summary
- replace business.json with real address, socials, and WhatsApp number
- apply brand font and hover styles to app shell & header links
- implement full Contact page with phone, Instagram, Facebook, and WhatsApp CTA
- polish Business CTA with gold hover on address link

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f7f6f1b48332ae1936c1f43ad453