### PR TITLE
Add footer component and centralize business data

### DIFF
--- a/public/data/business.json
+++ b/public/data/business.json
@@ -6,6 +6,14 @@
   "whatsapp": {
     "number": "2382489890",
     "prefill": "Hola El Ga’on, quiero ordenar: Gaonera x3 + Queso"
+  },
+  "hours": {
+    "monday": "6pm – 1am",
+    "tuesday": "6pm – 1am",
+    "wednesday": "6pm – 1am",
+    "thursday": "6pm – 1am",
+    "friday": "6pm – 1am",
+    "saturday": "6pm – 1am",
+    "sunday": "6pm – 1am"
   }
 }
-

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -16,36 +16,6 @@
   <router-outlet />
 </main>
 
-<footer
-  class="text-white/80 text-sm"
-  style="
-    background:
-      linear-gradient(#111 1px, transparent 1px),
-      linear-gradient(90deg, #111 1px, transparent 1px);
-    background-size: 32px 32px, 32px 32px;
-    background-position: 0 0, 0 0;
-    background-color: #0B0B0B;
-  ">
-  <div class="mx-auto max-w-6xl px-4 py-8 grid grid-cols-1 md:grid-cols-3 gap-6">
-    <div>
-      <div class="text-gold font-display text-lg mb-2">Taquería El Ga’on</div>
-      <div class="text-white/70">2 Poniente #218, Centro, Tehuacán, Puebla</div>
-    </div>
-    <div>
-      <div class="text-white mb-2">Horarios</div>
-      <div>Lun–Dom · 1:00 pm – 11:00 pm</div>
-    </div>
-    <div>
-      <div class="text-white mb-2">Social</div>
-      <div class="flex gap-4">
-        <a href="https://www.instagram.com/taqueria_el_gaon" target="_blank" rel="noopener"
-           class="hover:text-gold transition-colors">Instagram</a>
-        <a href="https://www.facebook.com/p/Taquería-El-Gaon-61574898375073" target="_blank" rel="noopener"
-           class="hover:text-gold transition-colors">Facebook</a>
-      </div>
-    </div>
-  </div>
-  <div class="mx-auto max-w-6xl px-4 pb-6 text-white/60">© {{ year }} Taquería El Ga’on</div>
-</footer>
+<app-footer></app-footer>
 
 <app-consent-banner></app-consent-banner>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,11 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { ConsentBannerComponent } from './components/consent-banner/consent-banner.component';
+import { FooterComponent } from './components/footer/footer.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, ConsentBannerComponent],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, ConsentBannerComponent, FooterComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/components/business-cta/business-cta.component.ts
+++ b/src/app/components/business-cta/business-cta.component.ts
@@ -22,9 +22,9 @@ import { AnalyticsService } from '../../core/analytics.service';
            class="px-5 py-3 rounded-lg bg-vermillion text-white font-semibold hover:opacity-90 transition">
           WhatsApp
         </a>
-        <a *ngIf="biz()?.instagram" [href]="'https://instagram.com/' + biz()?.instagram" target="_blank" rel="noopener"
+        <a *ngIf="biz()?.instagram" [attr.href]="biz()?.instagram" target="_blank" rel="noopener"
            class="text-white/80 hover:text-white">Instagram</a>
-        <a *ngIf="biz()?.facebook" [href]="'https://facebook.com/' + biz()?.facebook" target="_blank" rel="noopener"
+        <a *ngIf="biz()?.facebook" [attr.href]="biz()?.facebook" target="_blank" rel="noopener"
            class="text-white/80 hover:text-white">Facebook</a>
       </div>
     </div>

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -1,0 +1,75 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataService, Business } from '../../data/data.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-footer',
+  imports: [CommonModule],
+  template: `
+<footer class="bg-blackx text-white border-t border-white/10">
+  <div class="mx-auto max-w-6xl px-4 py-10 grid gap-8 md:grid-cols-3">
+    <!-- Address -->
+    <div>
+      <div class="text-white mb-2">Dirección</div>
+      <div class="text-white/80" *ngIf="biz() as b">
+        {{ b.address || 'Tehuacán, Puebla' }}
+      </div>
+    </div>
+
+    <!-- Hours -->
+    <div>
+      <div class="text-white mb-2">Horarios</div>
+      <div class="grid grid-cols-2 text-white/80 gap-y-1" *ngIf="biz() as b">
+        <div>Lunes</div><div class="text-right">{{ b.hours?.monday || '6pm – 1am' }}</div>
+        <div>Martes</div><div class="text-right">{{ b.hours?.tuesday || '6pm – 1am' }}</div>
+        <div>Miércoles</div><div class="text-right">{{ b.hours?.wednesday || '6pm – 1am' }}</div>
+        <div>Jueves</div><div class="text-right">{{ b.hours?.thursday || '6pm – 1am' }}</div>
+        <div>Viernes</div><div class="text-right">{{ b.hours?.friday || '6pm – 1am' }}</div>
+        <div>Sábado</div><div class="text-right">{{ b.hours?.saturday || '6pm – 1am' }}</div>
+        <div>Domingo</div><div class="text-right">{{ b.hours?.sunday || '6pm – 1am' }}</div>
+      </div>
+    </div>
+
+    <!-- Social with icons -->
+    <div>
+      <div class="text-white mb-2">Social</div>
+      <div class="flex items-center gap-4" *ngIf="biz() as b">
+        <a [attr.href]="b.instagram"
+           target="_blank" rel="noopener noreferrer"
+           class="group inline-flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-vermillion rounded-lg px-1"
+           aria-label="Instagram">
+          <!-- Instagram SVG -->
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+               class="w-6 h-6 fill-salsa group-hover:fill-gold transition-colors" aria-hidden="true">
+            <path d="M7 2h10a5 5 0 015 5v10a5 5 0 01-5 5H7a5 5 0 01-5-5V7a5 5 0 015-5zm0 2a3 3 0 00-3 3v10a3 3 0 003 3h10a3 3 0 003-3V7a3 3 0 00-3-3H7zm5 3.5a5.5 5.5 0 110 11 5.5 5.5 0 010-11zm0 2a3.5 3.5 0 100 7 3.5 3.5 0 000-7zM18 6.25a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5z"/>
+          </svg>
+          <span class="text-white/80 group-hover:text-gold transition-colors">Instagram</span>
+        </a>
+
+        <a [attr.href]="b.facebook"
+           target="_blank" rel="noopener noreferrer"
+           class="group inline-flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-vermillion rounded-lg px-1"
+           aria-label="Facebook">
+          <!-- Facebook SVG -->
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+               class="w-6 h-6 fill-salsa group-hover:fill-gold transition-colors" aria-hidden="true">
+            <path d="M13 3h3a1 1 0 011 1v3h-3a1 1 0 00-1 1v3h4l-1 4h-3v8h-4v-8H7v-4h3V8a5 5 0 015-5z"/>
+          </svg>
+          <span class="text-white/80 group-hover:text-gold transition-colors">Facebook</span>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="mx-auto max-w-6xl px-4 pb-6 text-white/60">
+    © {{ year }} Taquería El Ga’on
+  </div>
+</footer>
+  `
+})
+export class FooterComponent {
+  private data = inject(DataService);
+  readonly year = new Date().getFullYear();
+  biz = this.data.businessSignal;
+}

--- a/src/app/data/data.service.ts
+++ b/src/app/data/data.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { DOCUMENT } from '@angular/common';
 import { Observable, of, catchError } from 'rxjs';
@@ -21,6 +21,15 @@ export interface Business {
   address?: string;
   instagram?: string;
   facebook?: string;
+  hours?: {
+    monday?: string;
+    tuesday?: string;
+    wednesday?: string;
+    thursday?: string;
+    friday?: string;
+    saturday?: string;
+    sunday?: string;
+  };
   whatsapp?: { number?: string; prefill?: string };
 }
 
@@ -28,6 +37,11 @@ export interface Business {
 export class DataService {
   private http = inject(HttpClient);
   private doc = inject(DOCUMENT);
+  public businessSignal = signal<Business | null>(null);
+
+  constructor() {
+    this.business().subscribe(b => this.businessSignal.set(b));
+  }
 
   /**
    * Build a URL under the app's <base href>, e.g. '/taqueriaelgaon/data/...'

--- a/src/app/pages/contacto/contacto.component.ts
+++ b/src/app/pages/contacto/contacto.component.ts
@@ -30,7 +30,7 @@ import { DataService, Business } from '../../data/data.service';
           <div class="space-y-3">
             <div class="text-white/80">Instagram</div>
             <div class="font-medium">
-              <a [href]="b.instagram || 'https://www.instagram.com/taqueria_el_gaon'"
+              <a [attr.href]="b.instagram || 'https://www.instagram.com/taqueria_el_gaon'"
                  target="_blank" rel="noopener"
                  class="hover:text-gold transition-colors">
                  @taqueria_el_gaon
@@ -41,7 +41,7 @@ import { DataService, Business } from '../../data/data.service';
           <div class="space-y-3">
             <div class="text-white/80">Facebook</div>
             <div class="font-medium">
-              <a [href]="b.facebook || 'https://www.facebook.com/p/Taquería-El-Gaon-61574898375073'"
+              <a [attr.href]="b.facebook || 'https://www.facebook.com/p/Taquería-El-Gaon-61574898375073'"
                  target="_blank" rel="noopener"
                  class="hover:text-gold transition-colors">
                  Taquería El Ga’on


### PR DESCRIPTION
## Summary
- add weekly hours to business.json and expose through DataService
- create standalone FooterComponent showing business info and social icons
- use new footer across app and update social links to avoid URL concatenation

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build` *(fails: NotYetImplemented during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ff7dd2388332a192af109801b501